### PR TITLE
cfn-changelogger: Generating json source files for changelog tooling

### DIFF
--- a/changelogs/v8-changelog.json
+++ b/changelogs/v8-changelog.json
@@ -280,9 +280,10 @@
       "ResourceTypes": {},
       "Total": {
         "Change": [
+          3,
           0
         ],
-        "Value": 189
+        "Value": 6
       }
     }
   }

--- a/changelogs/v8-changelog.json
+++ b/changelogs/v8-changelog.json
@@ -1,0 +1,289 @@
+{
+  "8.0.0": {
+    "PropertyTypes": {
+      "AWS::ApiGatewayV2::Api.BodyS3Location": {
+        "AllRegions": false,
+        "Regions": [
+          "us-west-1"
+        ],
+        "Type": "New"
+      },
+      "AWS::ApiGatewayV2::Api.Cors": {
+        "AllRegions": false,
+        "Regions": [
+          "us-west-1"
+        ],
+        "Type": "New"
+      },
+      "AWS::ApiGatewayV2::Authorizer.JWTConfiguration": {
+        "AllRegions": false,
+        "Regions": [
+          "us-west-1"
+        ],
+        "Type": "New"
+      },
+      "AWS::AppStream::ImageBuilder.AccessEndpoint": {
+        "AllRegions": false,
+        "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appstream-imagebuilder-accessendpoint.html",
+        "Expanded": [
+          "us-east-1"
+        ],
+        "Reduced": [],
+        "Type": "Existing"
+      },
+      "AWS::AppStream::Stack.AccessEndpoint": {
+        "AllRegions": false,
+        "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appstream-stack-accessendpoint.html",
+        "Expanded": [
+          "us-east-1"
+        ],
+        "Reduced": [],
+        "Type": "Existing"
+      },
+      "AWS::AppSync::DataSource.DeltaSyncConfig": {
+        "AllRegions": false,
+        "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-datasource-deltasyncconfig.html",
+        "Expanded": [
+          "us-west-2"
+        ],
+        "Reduced": [],
+        "Type": "Existing"
+      },
+      "AWS::AppSync::Resolver.LambdaConfig": {
+        "AllRegions": false,
+        "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-resolver-lambdaconfig.html",
+        "Expanded": [
+          "us-west-2"
+        ],
+        "Reduced": [],
+        "Type": "Existing"
+      },
+      "AWS::AppSync::Resolver.SyncConfig": {
+        "AllRegions": false,
+        "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appsync-resolver-syncconfig.html",
+        "Expanded": [
+          "us-west-2"
+        ],
+        "Reduced": [],
+        "Type": "Existing"
+      },
+      "AWS::CodeStarNotifications::NotificationRule.Target": {
+        "AllRegions": false,
+        "Regions": [
+          "us-east-1",
+          "eu-north-1",
+          "ap-south-1",
+          "eu-west-3",
+          "eu-west-2",
+          "eu-west-1",
+          "ap-northeast-2",
+          "ap-northeast-1",
+          "sa-east-1",
+          "ca-central-1",
+          "ap-southeast-1",
+          "ap-southeast-2",
+          "eu-central-1",
+          "us-east-2",
+          "us-west-1",
+          "us-west-2"
+        ],
+        "Type": "New"
+      },
+      "AWS::MediaConvert::JobTemplate.AccelerationSettings": {
+        "AllRegions": false,
+        "Regions": [
+          "us-east-1",
+          "eu-north-1",
+          "ap-south-1",
+          "eu-west-3",
+          "eu-west-2",
+          "eu-west-1",
+          "ap-northeast-2",
+          "ap-northeast-1",
+          "sa-east-1",
+          "ca-central-1",
+          "ap-southeast-1",
+          "ap-southeast-2",
+          "eu-central-1",
+          "us-east-2",
+          "us-west-1",
+          "us-west-2"
+        ],
+        "Type": "New"
+      }
+    },
+    "ResourceSpecificationVersionOld": "7.4.0",
+    "ResourceTypes": {
+      "AWS::CodeStarNotifications::NotificationRule": {
+        "AllRegions": false,
+        "Regions": [
+          "us-east-1",
+          "eu-north-1",
+          "ap-south-1",
+          "eu-west-3",
+          "eu-west-2",
+          "eu-west-1",
+          "ap-northeast-2",
+          "ap-northeast-1",
+          "sa-east-1",
+          "ca-central-1",
+          "ap-southeast-1",
+          "ap-southeast-2",
+          "eu-central-1",
+          "us-east-2",
+          "us-west-1",
+          "us-west-2"
+        ],
+        "Type": "New"
+      },
+      "AWS::MediaConvert::JobTemplate": {
+        "AllRegions": false,
+        "Regions": [
+          "us-east-1",
+          "eu-north-1",
+          "ap-south-1",
+          "eu-west-3",
+          "eu-west-2",
+          "eu-west-1",
+          "ap-northeast-2",
+          "ap-northeast-1",
+          "sa-east-1",
+          "ca-central-1",
+          "ap-southeast-1",
+          "ap-southeast-2",
+          "eu-central-1",
+          "us-east-2",
+          "us-west-1",
+          "us-west-2"
+        ],
+        "Type": "New"
+      },
+      "AWS::MediaConvert::Preset": {
+        "AllRegions": false,
+        "Regions": [
+          "us-east-1",
+          "eu-north-1",
+          "ap-south-1",
+          "eu-west-3",
+          "eu-west-2",
+          "eu-west-1",
+          "ap-northeast-2",
+          "ap-northeast-1",
+          "sa-east-1",
+          "ca-central-1",
+          "ap-southeast-1",
+          "ap-southeast-2",
+          "eu-central-1",
+          "us-east-2",
+          "us-west-1",
+          "us-west-2"
+        ],
+        "Type": "New"
+      },
+      "AWS::MediaConvert::Queue": {
+        "AllRegions": false,
+        "Regions": [
+          "us-east-1",
+          "eu-north-1",
+          "ap-south-1",
+          "eu-west-3",
+          "eu-west-2",
+          "eu-west-1",
+          "ap-northeast-2",
+          "ap-northeast-1",
+          "sa-east-1",
+          "ca-central-1",
+          "ap-southeast-1",
+          "ap-southeast-2",
+          "eu-central-1",
+          "us-east-2",
+          "us-west-1",
+          "us-west-2"
+        ],
+        "Type": "New"
+      }
+    },
+    "Totals": {
+      "TotalPropertyTypes": {
+        "Change": [
+          5
+        ],
+        "Value": 1125
+      },
+      "TotalPropertyTypesSupportedGlobally": {
+        "Change": [
+          0
+        ],
+        "Value": 465
+      },
+      "TotalResourceTypes": {
+        "Change": [
+          4
+        ],
+        "Value": 467
+      },
+      "TotalResourceTypesSupportedGlobally": {
+        "Change": [
+          0
+        ],
+        "Value": 189
+      }
+    },
+    "TypesNotInUSEAST1": {
+      "PropertyTypes": {
+        "AWS::ApiGatewayV2::Api.BodyS3Location": {
+          "Fixed": false,
+          "Regions": [
+            "us-west-1"
+          ],
+          "Since": "8.0.0"
+        },
+        "AWS::ApiGatewayV2::Api.Cors": {
+          "Fixed": false,
+          "Regions": [
+            "us-west-1"
+          ],
+          "Since": "8.0.0"
+        },
+        "AWS::ApiGatewayV2::Authorizer.JWTConfiguration": {
+          "Fixed": false,
+          "Regions": [
+            "us-west-1"
+          ],
+          "Since": "8.0.0"
+        },
+        "AWS::AppSync::DataSource.DeltaSyncConfig": {
+          "Fixed": false,
+          "Regions": [
+            "us-east-2",
+            "us-west-2"
+          ],
+          "Since": "7.4.0"
+        },
+        "AWS::AppSync::Resolver.LambdaConfig": {
+          "Fixed": false,
+          "Regions": [
+            "us-east-2",
+            "us-west-2"
+          ],
+          "Since": "7.4.0"
+        },
+        "AWS::AppSync::Resolver.SyncConfig": {
+          "Fixed": false,
+          "Regions": [
+            "us-east-2",
+            "us-west-2"
+          ],
+          "Since": "7.4.0"
+        }
+      },
+      "ResourceTypes": {},
+      "Total": {
+        "Change": [
+          0
+        ],
+        "Value": 189
+      }
+    }
+  }
+}

--- a/tools/cfn-changelogger.py
+++ b/tools/cfn-changelogger.py
@@ -39,7 +39,7 @@ with open('supported-regions-per-resource.json', 'r') as file_to_read:
 # Change = [increase, decrease]
 for total in totals:
     changelog["Totals"][total] = {"Value": supported_new[total], "Change": [supported_new[total] - supported_old[total]]}
-changelog["TypesNotInUSEAST1"]["Total"] = {"Value": supported_new[total], "Change": [supported_new[total] - supported_old[total]]}
+changelog["TypesNotInUSEAST1"]["Total"] = {"Value": supported_new["TypesNotInUSEAST1"]["Total"], "Change": [0,0]}
 changelog["ResourceSpecificationVersionOld"] = supported_old["ResourceSpecificationVersion"]
 
 for each_type in ["ResourceTypes", "PropertyTypes"]:
@@ -72,12 +72,14 @@ for each_type in ["ResourceTypes", "PropertyTypes"]:
                 "Fixed": False,
                 "Regions": supported_new["TypesNotInUSEAST1"][each_type][resource]["Regions"]
             }
+            changelog["TypesNotInUSEAST1"]["Total"]["Change"][0] += 1
     for resource in supported_old["TypesNotInUSEAST1"][each_type].keys():
         if not supported_new[each_type].get(resource):
             changelog["TypesNotInUSEAST1"][each_type][resource] = {
                 "Since": supported_old["ResourceSpecificationVersion"],
                 "Fixed": True
             }
+            changelog["TypesNotInUSEAST1"]["Total"]["Change"][1] += 1
 
 changelog_major_version = supported_new["ResourceSpecificationVersion"].split('.')[0]
 target_json = Path(f"changelogs/v{changelog_major_version}-changelog.json")

--- a/tools/cfn-changelogger.py
+++ b/tools/cfn-changelogger.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+
+def compare_regions(new_list_type, old_list_type):
+    expanded_regions = list(set(new_list_type["Regions"]) - set(old_list_type["Regions"]))
+    reduced_regions = list(set(old_list_type["Regions"]) - set(new_list_type["Regions"]))
+    if expanded_regions or reduced_regions:
+        if new_list_type["AllRegions"] == True:
+            return {'Expanded': expanded_regions, 'AllRegions': True}
+        else:
+            return {'Expanded': expanded_regions, 'Reduced': reduced_regions, 'AllRegions': False}
+    else:
+        return None
+
+
+changelog = {
+    "PropertyTypes" : {},
+    "ResourceTypes" : {},
+    "Totals": {},
+    "TypesNotInUSEAST1": {"ResourceTypes": {}, "PropertyTypes": {}}
+}
+
+totals = [
+    "TotalPropertyTypes",
+    "TotalPropertyTypesSupportedGlobally",
+    "TotalResourceTypes",
+    "TotalResourceTypesSupportedGlobally"
+]
+
+# Import old
+with open('testing/supported-regions-per-resource-old.json', 'r') as file_to_read:
+    supported_old = json.loads(file_to_read.read())
+
+# Import new
+with open('supported-regions-per-resource.json', 'r') as file_to_read:
+    supported_new = json.loads(file_to_read.read())
+
+# Change = [increase, decrease]
+for total in totals:
+    changelog["Totals"][total] = {"Value": supported_new[total], "Change": [supported_new[total] - supported_old[total]]}
+changelog["TypesNotInUSEAST1"]["Total"] = {"Value": supported_new[total], "Change": [supported_new[total] - supported_old[total]]}
+changelog["ResourceSpecificationVersionOld"] = supported_old["ResourceSpecificationVersion"]
+
+for each_type in ["ResourceTypes", "PropertyTypes"]:
+    for resource in supported_new[each_type].keys():
+        if supported_old[each_type].get(resource):
+            diff = compare_regions(supported_new[each_type][resource], supported_old[each_type][resource])
+            if diff:
+                diff["Type"] = 'Existing'
+                diff["Documentation"] = supported_new[each_type][resource]["Documentation"]
+                changelog[each_type][resource] = diff
+        else:
+            changelog[each_type][resource] =  {
+                "Type": "New",
+                "AllRegions": supported_new[each_type][resource]["AllRegions"],
+                "Regions": supported_new[each_type][resource]["Regions"]
+            }
+
+
+for each_type in ["ResourceTypes", "PropertyTypes"]:
+    for resource in supported_new["TypesNotInUSEAST1"][each_type].keys():
+        if supported_old[each_type].get(resource):
+            changelog["TypesNotInUSEAST1"][each_type][resource] = {
+                "Since": supported_old["ResourceSpecificationVersion"],
+                "Fixed": False,
+                "Regions": supported_new["TypesNotInUSEAST1"][each_type][resource]["Regions"]
+            }
+        else:
+            changelog["TypesNotInUSEAST1"][each_type][resource] = {
+                "Since": supported_new["ResourceSpecificationVersion"],
+                "Fixed": False,
+                "Regions": supported_new["TypesNotInUSEAST1"][each_type][resource]["Regions"]
+            }
+    for resource in supported_old["TypesNotInUSEAST1"][each_type].keys():
+        if not supported_new[each_type].get(resource):
+            changelog["TypesNotInUSEAST1"][each_type][resource] = {
+                "Since": supported_old["ResourceSpecificationVersion"],
+                "Fixed": True
+            }
+
+changelog_major_version = supported_new["ResourceSpecificationVersion"].split('.')[0]
+target_json = Path(f"changelogs/v{changelog_major_version}-changelog.json")
+
+# Check if existing changelog
+if target_json.exists():
+    with open(target_json, 'r') as file_to_read:
+        current_changelog = json.loads(file_to_read.read())
+    current_changelog[supported_new["ResourceSpecificationVersion"]] = changelog
+else:
+    current_changelog = {supported_new["ResourceSpecificationVersion"]: changelog}
+
+# Write changelog
+with open(target_json, 'w') as file_to_dump:
+    json.dump(current_changelog, file_to_dump, indent=2, sort_keys=True)

--- a/tools/cfn-resource-list.py
+++ b/tools/cfn-resource-list.py
@@ -168,8 +168,8 @@ version_master.sort(key=StrictVersion)
 if updated_regions:
     repo = git.Repo(f"{Path.cwd()}") # git repo base info
     if not debugging:
-        git_email = os.environ['GITHUB_ACTOR']
-        git_name = os.environ['GITHUB_ACTOR'] + '@users.noreply.github.com'
+        git_email = os.environ['GITHUB_ACTOR'] + '@users.noreply.github.com'
+        git_name = os.environ['GITHUB_ACTOR']
         github_repo = os.environ['GITHUB_REPOSITORY']
         github_token = os.environ['GITHUB_TOKEN']
         repo.git.config('--global', 'user.email', f"{git_email}")


### PR DESCRIPTION
This is the first step to resolving #17 and for any other project maintainers who want to use machine-readable changelog json data.