### PR TITLE
af-south-1 (Cape Town)

### DIFF
--- a/regions.json
+++ b/regions.json
@@ -1,4 +1,8 @@
 {
+  "af-south-1": {
+    "name": "Africa (Cape Town)",
+    "normal_s3_download": false
+  },
   "ap-east-1": {
     "name": "Asia Pacific (Hong Kong)",
     "normal_s3_download": false


### PR DESCRIPTION
https://aws.amazon.com/blogs/aws/now-open-aws-africa-cape-town-region/
https://aws.amazon.com/about-aws/whats-new/2020/04/announcing-aws-africa-cape-town-region/
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html

Not sure this is everything needed, but figured I'd try copying from [`eu-south-1 (Milan)`](https://github.com/ScriptAutomate/aws-cfn-resource-specs/commit/9b788b71caf191cc0ff16b82a82e37604f54fe58)